### PR TITLE
Fix multiple problems in loadUserByUsername mechanism

### DIFF
--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
@@ -78,7 +78,7 @@ public class TuleapAuthorizationCodeUrlBuilderImplTest {
             "response_type=code" +
             "&client_id=123" +
             "&redirect_uri=" + URLEncoder.encode("https://jenkins.example.com/securityRealm/finishLogin", UTF_8.name()) +
-            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile", UTF_8.name()) +
+            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile offline_access", UTF_8.name()) +
             "&state=Brabus" +
             "&code_challenge=B35S" +
             "&code_challenge_method=S256" +


### PR DESCRIPTION
This change is part of [story #14019](https://my.enalean.com/goto?key=community&val=14019&group_id=147)

* Do not search for access token if user is unknown
* Refresh token if it is expired