### PR TITLE
Add plugin helper

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
@@ -388,5 +388,10 @@ public class TuleapSecurityRealm extends SecurityRealm {
             }
             return FormValidation.ok();
         }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/tuleap-oauth/helpTuleapSecurityRealm/helpTuleapRealm/help.html";
+        }
     }
 }

--- a/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help.html
+++ b/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help.html
@@ -1,0 +1,21 @@
+<div>
+    By using this realm, user will be able to use their Tuleap account to be connected on the Jenkins server. <br/>
+    To be authenticated with Tuleap, you have to add the Jenkins redirection endpoint in your <a
+        href="https://docs.tuleap.org/user-guide/oauth2.html#openidconnect-provider">
+    Tuleap OAuth2 app.</a> <br/>
+    The format of the Jenkins redirection endpoint is: https://your_jenkins_server/securityRealm/finishLogin
+    <br/> <br/>
+
+    <strong>NOTES:</strong>
+    <ul>
+        <li> The OAuth2 module is a <a
+                href="https://docs.tuleap.org/user-guide/tuleap-entreprise.html#tuleap-enterprise">
+            Tuleap Enterprise module </a>
+        </li>
+        <li> Your Jenkins server <strong>MUST</strong> be in HTTPS</li>
+        <li> The PKCE usage <strong>MUST</strong> be enabled in your <a
+                href="https://docs.tuleap.org/user-guide/oauth2.html#openidconnect-provider">
+            Tuleap OAuth2 app</a>
+        </li>
+    </ul>
+</div>

--- a/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
+++ b/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
@@ -1,7 +1,7 @@
 <div>
     En utilisant ce domaine, les utilisateurs Jenkins peuvent utiliser leur compte Tuleap pour se connecter au serveur
     Jenkins. <br/>
-    Pour pouvoir être autentifié en utilisant Tuleap, vous devez rajouter l'URL de redirection du serveur Jenkins dans
+    Pour pouvoir être authentifié en utilisant Tuleap, vous devez rajouter l'URL de redirection du serveur Jenkins dans
     votre application Tuleap OAuth2 <br/>
     L'URL de redirection est de la forme suivante: https://your_jenkins_server.example.com/securityRealm/finishLogin
     <br/> <br/>

--- a/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
+++ b/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
@@ -1,5 +1,5 @@
 <div>
-    En utilisant se domaine, les utilisateurs Jenkins peuvent utiliser leur compte Tuleap pour se connecter au serveur
+    En utilisant ce domaine, les utilisateurs Jenkins peuvent utiliser leur compte Tuleap pour se connecter au serveur
     Jenkins. <br/>
     Pour pouvoir être autentifié en utilisant Tuleap, vous devez rajouter l'URL de redirection du serveur Jenkins dans
     votre application Tuleap OAuth2 <br/>

--- a/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
+++ b/src/main/webapp/helpTuleapSecurityRealm/helpTuleapRealm/help_fr.html
@@ -1,0 +1,21 @@
+<div>
+    En utilisant se domaine, les utilisateurs Jenkins peuvent utiliser leur compte Tuleap pour se connecter au serveur
+    Jenkins. <br/>
+    Pour pouvoir être autentifié en utilisant Tuleap, vous devez rajouter l'URL de redirection du serveur Jenkins dans
+    votre application Tuleap OAuth2 <br/>
+    L'URL de redirection est de la forme suivante: https://your_jenkins_server.example.com/securityRealm/finishLogin
+    <br/> <br/>
+
+    <strong>REMARQUES :</strong>
+    <ul>
+        <li>Le module OAuth2 est un <a
+                href="https://docs.tuleap.org/user-guide/tuleap-entreprise.html#tuleap-enterprise">
+            module Tuleap Enterprise</a>
+        </li>
+        <li> Votre serveur Jenkins <strong>DOIT</strong> être en HTTPS</li>
+        <li> L'usage du PKCE <strong>DOIT</strong> être activé dans votre <a
+                href="https://docs.tuleap.org/user-guide/oauth2.html#openidconnect-provider">
+            application OAuth2 Tuleap</a>
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
This is a part of [request #15033](https://tuleap.net/plugins/tracker/?aid=15033) Improve the Jenkins Authentication plugin

In the Security Realm menu you should see a helper next to "Tuleap Authentication" radio button.