### PR TITLE
Fill some missing information in the profile of the connected user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>tuleap-api</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImpl.java
@@ -15,6 +15,10 @@ public class UserInfoCheckerImpl implements UserInfoChecker {
             LOGGER.warning("Subject not expected");
             return false;
         }
+        if (!userInfo.isEmailVerified()) {
+            LOGGER.warning("Invalid user");
+            return false;
+        }
         return true;
     }
 }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/UserInfoCheckerImplTest.java
@@ -22,9 +22,23 @@ public class UserInfoCheckerImplTest {
     }
 
     @Test
+    public void testItReturnFalseWhenTheUserIsInvalid() {
+        UserInfo userInfo = mock(UserInfo.class);
+        when(userInfo.getSubject()).thenReturn("1510");
+        when(userInfo.isEmailVerified()).thenReturn(false);
+
+        DecodedJWT idToken = mock(DecodedJWT.class);
+        when(idToken.getSubject()).thenReturn("1510");
+
+        UserInfoCheckerImpl userInfoChecker = new UserInfoCheckerImpl();
+        assertFalse(userInfoChecker.checkUserInfoResponseBody(userInfo, idToken));
+    }
+
+    @Test
     public void testItReturnTrueIfTheBodyIsOk() {
         UserInfo userInfo = mock(UserInfo.class);
         when(userInfo.getSubject()).thenReturn("123");
+        when(userInfo.isEmailVerified()).thenReturn(true);
 
         DecodedJWT idToken = mock(DecodedJWT.class);
         when(idToken.getSubject()).thenReturn("123");

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
@@ -78,7 +78,7 @@ public class TuleapAuthorizationCodeUrlBuilderImplTest {
             "response_type=code" +
             "&client_id=123" +
             "&redirect_uri=" + URLEncoder.encode("https://jenkins.example.com/securityRealm/finishLogin", UTF_8.name()) +
-            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile", UTF_8.name()) +
+            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile email", UTF_8.name()) +
             "&state=Brabus" +
             "&code_challenge=B35S" +
             "&code_challenge_method=S256" +


### PR DESCRIPTION
This is a part of [request #15033](https://tuleap.net/plugins/tracker/?aid=15033) Improve the Jenkins Authentication plugin

Now the full Tuleap username is displayed when the user is connected
The email of the connected user is now set in this profile. If the user already has set a mail then the mail does not change.