### PR TITLE
Check Tuleap Groups directly on Tuleap server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>tuleap-api</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapAuthenticationToken.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapAuthenticationToken.java
@@ -7,7 +7,7 @@ public class TuleapAuthenticationToken extends AbstractAuthenticationToken {
 
     private static final long serialVersionUID = 1L;
 
-    private final transient AccessToken accessToken;
+    private transient AccessToken accessToken;
     private final TuleapUserDetails tuleapUserDetails;
 
     public TuleapAuthenticationToken(
@@ -37,5 +37,9 @@ public class TuleapAuthenticationToken extends AbstractAuthenticationToken {
 
     public AccessToken getAccessToken() {
         return this.accessToken;
+    }
+
+    public void setAccessToken(AccessToken accessToken) {
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapGroupDetails.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapGroupDetails.java
@@ -1,10 +1,9 @@
 package io.jenkins.plugins.tuleap_oauth;
 
 import hudson.security.GroupDetails;
+import io.jenkins.plugins.tuleap_oauth.helper.TuleapGroupHelper;
 
 public class TuleapGroupDetails extends GroupDetails {
-    public static final String GROUP_SEPARATOR = "#";
-
     private final String groupName;
 
     public TuleapGroupDetails(final String groupName) {
@@ -18,6 +17,6 @@ public class TuleapGroupDetails extends GroupDetails {
 
     @Override
     public String getDisplayName() {
-        return String.join(" / ", this.groupName.split(GROUP_SEPARATOR));
+        return String.join(" / ", this.groupName.split(TuleapGroupHelper.GROUP_SEPARATOR));
     }
 }

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapOAuthClientConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapOAuthClientConfiguration.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.tuleap_oauth;
+
+import hudson.util.Secret;
+
+public class TuleapOAuthClientConfiguration {
+    private final String clientId;
+    private final Secret clientSecret;
+
+    public TuleapOAuthClientConfiguration (
+        final String clientId,
+        final Secret clientSecret
+    ) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public Secret getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
@@ -226,8 +226,8 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
         final Authentication authenticatedUserAcegiToken = this.pluginHelper.getCurrentUserAuthenticationToken();
 
-        if (! this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)) {
-            throw new UserMayOrMayNotExistException("Not a Tuleap Group");
+        if (! this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)) {
+            throw new UsernameNotFoundException("Not a Tuleap Group");
         }
 
         if (authenticatedUserAcegiToken == null) {

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
@@ -28,6 +28,7 @@ import io.jenkins.plugins.tuleap_oauth.checks.UserInfoChecker;
 import io.jenkins.plugins.tuleap_oauth.guice.TuleapOAuth2GuiceModule;
 import io.jenkins.plugins.tuleap_oauth.helper.PluginHelper;
 import io.jenkins.plugins.tuleap_oauth.helper.TuleapAuthorizationCodeUrlBuilder;
+import io.jenkins.plugins.tuleap_oauth.helper.TuleapGroupHelper;
 import io.jenkins.plugins.tuleap_oauth.helper.UserAuthoritiesRetriever;
 import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
 import jenkins.model.Jenkins;
@@ -50,7 +51,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 public class TuleapSecurityRealm extends SecurityRealm {
 
@@ -69,7 +69,7 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
     public static final String AUTHORIZATION_ENDPOINT = "oauth2/authorize?";
 
-    public static final String SCOPES = "read:project read:user_membership openid profile email";
+    public static final String SCOPES = "read:project read:user_membership openid profile email offline_access";
     public static final String CODE_CHALLENGE_METHOD = "S256";
 
     private AuthorizationCodeChecker authorizationCodeChecker;
@@ -84,6 +84,7 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
     private AccessTokenApi accessTokenApi;
     private OpenIDClientApi openIDClientApi;
+    private TuleapGroupHelper tuleapGroupHelper;
 
     @DataBoundConstructor
     public TuleapSecurityRealm(String clientId, String clientSecret) {
@@ -146,6 +147,11 @@ public class TuleapSecurityRealm extends SecurityRealm {
         this.userAuthoritiesRetriever = userAuthoritiesRetriever;
     }
 
+    @Inject
+    public void setTuleapGroupHelper(TuleapGroupHelper tuleapGroupHelper) {
+        this.tuleapGroupHelper = tuleapGroupHelper;
+    }
+
     private void injectInstances() {
         if (this.pluginHelper == null ||
             this.authorizationCodeChecker == null ||
@@ -156,7 +162,8 @@ public class TuleapSecurityRealm extends SecurityRealm {
             this.accessTokenApi == null ||
             this.openIDClientApi == null ||
             this.tuleapUserPropertyStorage == null ||
-            this.userAuthoritiesRetriever == null
+            this.userAuthoritiesRetriever == null ||
+            this.tuleapGroupHelper == null
         ) {
             Guice.createInjector(new TuleapOAuth2GuiceModule()).injectMembers(this);
         }
@@ -181,6 +188,13 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
     private void setClientSecret(String secretString) {
         this.clientSecret = Secret.fromString(secretString);
+    }
+
+    private TuleapOAuthClientConfiguration buildTuleapOAuthClientConfiguration() {
+        return new TuleapOAuthClientConfiguration(
+            this.clientId,
+            this.clientSecret
+        );
     }
 
     @Override
@@ -208,7 +222,13 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
     @Override
     public GroupDetails loadGroupByGroupname(String groupName) {
+        this.injectInstances();
+
         final Authentication authenticatedUserAcegiToken = this.pluginHelper.getCurrentUserAuthenticationToken();
+
+        if (! this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)) {
+            throw new UserMayOrMayNotExistException("Not a Tuleap Group");
+        }
 
         if (authenticatedUserAcegiToken == null) {
             throw new UserMayOrMayNotExistException("No access token found for user");
@@ -220,21 +240,11 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
         final TuleapAuthenticationToken tuleapAuthenticationToken = (TuleapAuthenticationToken) authenticatedUserAcegiToken;
 
-        if (! this.tokenHasTuleapGroup(tuleapAuthenticationToken, groupName)) {
-            throw new UsernameNotFoundException("Group " + groupName + " not found for current Tuleap user");
+        if (this.tuleapGroupHelper.groupExistsOnTuleapServer(groupName, tuleapAuthenticationToken, this.buildTuleapOAuthClientConfiguration())) {
+            return new TuleapGroupDetails(groupName);
         }
 
-        return new TuleapGroupDetails(groupName);
-    }
-
-    private Boolean tokenHasTuleapGroup(TuleapAuthenticationToken token, String groupName) {
-        return token
-            .getTuleapUserDetails()
-            .getTuleapAuthorities()
-            .stream()
-            .map(GrantedAuthority::getAuthority)
-            .collect(Collectors.toList())
-            .contains(groupName);
+        throw new UsernameNotFoundException("Could not find group " + groupName + " for Tuleap");
     }
 
     @Override
@@ -288,7 +298,12 @@ public class TuleapSecurityRealm extends SecurityRealm {
         final String codeVerifier = (String) request.getSession().getAttribute(CODE_VERIFIER_SESSION_ATTRIBUTE);
         final String authorizationCode = request.getParameter("code");
 
-        AccessToken accessToken = this.accessTokenApi.getAccessToken(codeVerifier, authorizationCode, this.clientId, this.clientSecret);
+        AccessToken accessToken = this.accessTokenApi.getAccessToken(
+            codeVerifier,
+            authorizationCode,
+            this.clientId,
+            this.clientSecret
+        );
 
         if (!this.accessTokenChecker.checkResponseBody(accessToken)) {
             return HttpResponses.redirectTo(this.getJenkinsInstance().getRootUrl() + TuleapAuthenticationErrorAction.REDIRECT_ON_AUTHENTICATION_ERROR);

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImpl.java
@@ -49,6 +49,7 @@ public class TuleapAuthorizationCodeUrlBuilderImpl implements TuleapAuthorizatio
 
         return tuleapUri + TuleapSecurityRealm.AUTHORIZATION_ENDPOINT +
             "response_type=code" +
+            "&prompt=consent" +
             "&client_id=" + URLEncoder.encode(clientId, UTF_8.name()) +
             "&redirect_uri=" + redirectUri +
             "&scope=" + URLEncoder.encode(TuleapSecurityRealm.SCOPES, UTF_8.name()) +

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
@@ -30,19 +30,19 @@ public class TuleapGroupHelper {
         return userGroup.getProjectName() + GROUP_SEPARATOR + userGroup.getGroupName();
     }
 
-    public Boolean groupNameIsOfTuleapFormat(String groupName) {
+    public Boolean groupNameIsInTuleapFormat(String groupName) {
         return StringUtils.countMatches(groupName, GROUP_SEPARATOR) == 1;
     }
 
     public Boolean groupExistsOnTuleapServer(
-        final String groupname,
+        final String groupName,
         final TuleapAuthenticationToken authenticationToken,
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
     ) {
         try {
             final ImmutableList<UserGroup> groups = this.getGroupsForTuleapProject(
                 this.getProjectFromTuleapServer(
-                    this.getTuleapProjectName(groupname),
+                    this.getTuleapProjectName(groupName),
                     authenticationToken,
                     tuleapOAuthClientConfiguration
                 ),
@@ -50,7 +50,7 @@ public class TuleapGroupHelper {
                 tuleapOAuthClientConfiguration
             );
 
-            return groups.stream().anyMatch(userGroup -> userGroup.getGroupName().equals(this.getTuleapGroupName(groupname)));
+            return groups.stream().anyMatch(userGroup -> userGroup.getGroupName().equals(this.getTuleapGroupName(groupName)));
         } catch (ProjectNotFoundException exception) {
             return false;
         }

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
@@ -1,0 +1,111 @@
+package io.jenkins.plugins.tuleap_oauth.helper;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.jenkins.plugins.tuleap_api.client.Project;
+import io.jenkins.plugins.tuleap_api.client.ProjectApi;
+import io.jenkins.plugins.tuleap_api.client.UserGroup;
+import io.jenkins.plugins.tuleap_api.client.authentication.AccessTokenApi;
+import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
+import io.jenkins.plugins.tuleap_oauth.TuleapAuthenticationToken;
+import io.jenkins.plugins.tuleap_oauth.TuleapOAuthClientConfiguration;
+import org.apache.commons.lang.StringUtils;
+
+public class TuleapGroupHelper {
+    public static final String GROUP_SEPARATOR = "#";
+
+    private final ProjectApi projectApi;
+    private final AccessTokenApi accessTokenApi;
+
+    @Inject
+    public TuleapGroupHelper(
+        final ProjectApi projectApi,
+        final AccessTokenApi accessTokenApi
+    ) {
+        this.projectApi = projectApi;
+        this.accessTokenApi = accessTokenApi;
+    }
+
+    public String buildJenkinsName(UserGroup userGroup) {
+        return userGroup.getProjectName() + GROUP_SEPARATOR + userGroup.getGroupName();
+    }
+
+    public Boolean groupNameIsOfTuleapFormat(String groupName) {
+        return StringUtils.countMatches(groupName, GROUP_SEPARATOR) == 1;
+    }
+
+    public Boolean groupExistsOnTuleapServer(
+        final String groupname,
+        final TuleapAuthenticationToken authenticationToken,
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
+    ) {
+        try {
+            final ImmutableList<UserGroup> groups = this.getGroupsForTuleapProject(
+                this.getProjectFromTuleapServer(
+                    this.getTuleapProjectName(groupname),
+                    authenticationToken,
+                    tuleapOAuthClientConfiguration
+                ),
+                authenticationToken,
+                tuleapOAuthClientConfiguration
+            );
+
+            return groups.stream().anyMatch(userGroup -> userGroup.getGroupName().equals(this.getTuleapGroupName(groupname)));
+        } catch (ProjectNotFoundException exception) {
+            return false;
+        }
+    }
+
+    private ImmutableList<UserGroup> getGroupsForTuleapProject(
+        final Project project,
+        final TuleapAuthenticationToken authenticationToken,
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
+    ) {
+        try {
+            return this.projectApi.getProjectUserGroups(project.getId(), authenticationToken.getAccessToken());
+        } catch (RuntimeException exception) {
+            this.tryToRefreshAccessToken(
+                authenticationToken,
+                tuleapOAuthClientConfiguration
+            );
+            return this.projectApi.getProjectUserGroups(project.getId(), authenticationToken.getAccessToken());
+        }
+    }
+
+    private Project getProjectFromTuleapServer(
+        final String shortName,
+        final TuleapAuthenticationToken authenticationToken,
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
+    ) throws ProjectNotFoundException{
+        try {
+            return this.projectApi.getProjectByShortname(shortName, authenticationToken.getAccessToken());
+        } catch (RuntimeException exception) {
+            this.tryToRefreshAccessToken(
+                authenticationToken,
+                tuleapOAuthClientConfiguration
+            );
+            return this.projectApi.getProjectByShortname(shortName, authenticationToken.getAccessToken());
+        }
+    }
+
+    private void tryToRefreshAccessToken(
+        final TuleapAuthenticationToken authenticationToken,
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
+    ) {
+        authenticationToken.setAccessToken(
+            this.accessTokenApi.refreshToken(
+                authenticationToken.getAccessToken(),
+                tuleapOAuthClientConfiguration.getClientId(),
+                tuleapOAuthClientConfiguration.getClientSecret()
+            )
+        );
+    }
+
+    private String getTuleapProjectName(String groupName) {
+        return StringUtils.split(groupName, GROUP_SEPARATOR)[0];
+    }
+
+    private String getTuleapGroupName(String groupName) {
+        return StringUtils.split(groupName, GROUP_SEPARATOR)[1];
+    }
+}

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetriever.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetriever.java
@@ -13,17 +13,19 @@ import java.util.stream.Collectors;
 
 public class UserAuthoritiesRetriever {
     private final UserApi userApi;
+    private final TuleapGroupHelper tuleapGroupHelper;
 
     @Inject
-    public UserAuthoritiesRetriever(final UserApi userApi) {
+    public UserAuthoritiesRetriever(final UserApi userApi, final TuleapGroupHelper tuleapGroupHelper) {
         this.userApi = userApi;
+        this.tuleapGroupHelper = tuleapGroupHelper;
     }
 
     public List<GrantedAuthority> getAuthoritiesForUser(final AccessToken accessToken) {
         final List<UserGroup> userGroups = this.userApi.getUserMembershipName(accessToken);
 
         return userGroups.stream()
-            .map(userGroup -> new GrantedAuthorityImpl(userGroup.getProjectName() + TuleapGroupDetails.GROUP_SEPARATOR + userGroup.getGroupName()))
+            .map(userGroup -> new GrantedAuthorityImpl(this.tuleapGroupHelper.buildJenkinsName(userGroup)))
             .collect(Collectors.toList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealmTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealmTest.java
@@ -10,10 +10,7 @@ import io.jenkins.plugins.tuleap_api.client.authentication.OpenIDClientApi;
 import io.jenkins.plugins.tuleap_oauth.checks.AccessTokenChecker;
 import io.jenkins.plugins.tuleap_oauth.checks.AuthorizationCodeChecker;
 import io.jenkins.plugins.tuleap_oauth.checks.IDTokenChecker;
-import io.jenkins.plugins.tuleap_oauth.helper.PluginHelper;
-import io.jenkins.plugins.tuleap_oauth.helper.PluginHelperImpl;
-import io.jenkins.plugins.tuleap_oauth.helper.TuleapAuthorizationCodeUrlBuilder;
-import io.jenkins.plugins.tuleap_oauth.helper.UserAuthoritiesRetriever;
+import io.jenkins.plugins.tuleap_oauth.helper.*;
 import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
@@ -38,6 +35,7 @@ public class TuleapSecurityRealmTest {
     private OpenIDClientApi openIDClientApi;
     private TuleapUserPropertyStorage tuleapUserPropertyStorage;
     private UserAuthoritiesRetriever userAuthoritiesRetriever;
+    private TuleapGroupHelper tuleapGroupHelper;
 
     private Jenkins jenkins;
 
@@ -52,6 +50,7 @@ public class TuleapSecurityRealmTest {
         this.openIDClientApi = mock(OpenIDClientApi.class);
         this.tuleapUserPropertyStorage = mock(TuleapUserPropertyStorage.class);
         this.userAuthoritiesRetriever = mock(UserAuthoritiesRetriever.class);
+        this.tuleapGroupHelper = mock(TuleapGroupHelper.class);
         this.gson = mock(Gson.class);
 
         this.jenkins = mock(Jenkins.class);
@@ -69,6 +68,7 @@ public class TuleapSecurityRealmTest {
         securityRealm.setOpenIDClientApi(this.openIDClientApi);
         securityRealm.setTuleapUserPropertyStorage(this.tuleapUserPropertyStorage);
         securityRealm.setUserAuthoritiesRetriever(this.userAuthoritiesRetriever);
+        securityRealm.setTuleapGroupHelper(this.tuleapGroupHelper);
     }
 
     @Test
@@ -239,12 +239,14 @@ public class TuleapSecurityRealmTest {
         userDetails.addTuleapAuthority(new GrantedAuthorityImpl(groupName));
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
+        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(true);
+        when(this.tuleapGroupHelper.groupExistsOnTuleapServer(eq(groupName), eq(token), any())).thenReturn(true);
 
         assertEquals(tuleapSecurityRealm.loadGroupByGroupname(groupName).getName(), groupName);
     }
 
     @Test(expected = UsernameNotFoundException.class)
-    public void testItShouldNotReturnATuleapGroupDetailIfGroupIsNotInUserToken() {
+    public void testItShouldNotReturnATuleapGroupDetailIfGroupIsNotFoundableOnTuleap() {
         TuleapSecurityRealm tuleapSecurityRealm = new TuleapSecurityRealm( "", "");
         this.injectMock(tuleapSecurityRealm);
 
@@ -254,6 +256,8 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
+        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(true);
+        when(this.tuleapGroupHelper.groupExistsOnTuleapServer(eq(groupName), eq(token), any())).thenReturn(false);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
     }
@@ -279,6 +283,22 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(null);
+
+        tuleapSecurityRealm.loadGroupByGroupname(groupName);
+    }
+
+    @Test(expected = UserMayOrMayNotExistException.class)
+    public void testItShouldNotReturnATuleapGroupDetailIfGroupNameIsNotOfTuleapFormat() {
+        TuleapSecurityRealm tuleapSecurityRealm = new TuleapSecurityRealm("", "");
+        this.injectMock(tuleapSecurityRealm);
+
+        final AccessToken accessToken = mock(AccessToken.class);
+        final TuleapUserDetails userDetails = new TuleapUserDetails("someUser");
+        final TuleapAuthenticationToken token  = new TuleapAuthenticationToken(userDetails, accessToken);
+        final String groupName = "use-me#project_members";
+
+        when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
+        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(false);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
     }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealmTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealmTest.java
@@ -239,7 +239,7 @@ public class TuleapSecurityRealmTest {
         userDetails.addTuleapAuthority(new GrantedAuthorityImpl(groupName));
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
-        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(true);
+        when(this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)).thenReturn(true);
         when(this.tuleapGroupHelper.groupExistsOnTuleapServer(eq(groupName), eq(token), any())).thenReturn(true);
 
         assertEquals(tuleapSecurityRealm.loadGroupByGroupname(groupName).getName(), groupName);
@@ -256,7 +256,7 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
-        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(true);
+        when(this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)).thenReturn(true);
         when(this.tuleapGroupHelper.groupExistsOnTuleapServer(eq(groupName), eq(token), any())).thenReturn(false);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
@@ -271,6 +271,7 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
+        when(this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)).thenReturn(true);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
     }
@@ -283,11 +284,12 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(null);
+        when(this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)).thenReturn(true);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
     }
 
-    @Test(expected = UserMayOrMayNotExistException.class)
+    @Test(expected = UsernameNotFoundException.class)
     public void testItShouldNotReturnATuleapGroupDetailIfGroupNameIsNotOfTuleapFormat() {
         TuleapSecurityRealm tuleapSecurityRealm = new TuleapSecurityRealm("", "");
         this.injectMock(tuleapSecurityRealm);
@@ -298,7 +300,7 @@ public class TuleapSecurityRealmTest {
         final String groupName = "use-me#project_members";
 
         when(this.pluginHelper.getCurrentUserAuthenticationToken()).thenReturn(token);
-        when(this.tuleapGroupHelper.groupNameIsOfTuleapFormat(groupName)).thenReturn(false);
+        when(this.tuleapGroupHelper.groupNameIsInTuleapFormat(groupName)).thenReturn(false);
 
         tuleapSecurityRealm.loadGroupByGroupname(groupName);
     }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
@@ -76,9 +76,10 @@ public class TuleapAuthorizationCodeUrlBuilderImplTest {
 
         String expectedUri = "https://tuleap.example.com/oauth2/authorize?" +
             "response_type=code" +
+            "&prompt=consent" +
             "&client_id=123" +
             "&redirect_uri=" + URLEncoder.encode("https://jenkins.example.com/securityRealm/finishLogin", UTF_8.name()) +
-            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile email", UTF_8.name()) +
+            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile email offline_access", UTF_8.name()) +
             "&state=Brabus" +
             "&code_challenge=B35S" +
             "&code_challenge_method=S256" +

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
@@ -38,9 +38,9 @@ public class TuleapGroupHelperTest {
             mock(AccessTokenApi.class)
         );
 
-        assertTrue(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-me#Contributors"));
-        assertFalse(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-me#Contributors#test"));
-        assertFalse(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-meContributorstest"));
+        assertTrue(tuleapGroupHelper.groupNameIsInTuleapFormat("use-me#Contributors"));
+        assertFalse(tuleapGroupHelper.groupNameIsInTuleapFormat("use-me#Contributors#test"));
+        assertFalse(tuleapGroupHelper.groupNameIsInTuleapFormat("use-meContributorstest"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
@@ -1,0 +1,130 @@
+package io.jenkins.plugins.tuleap_oauth.helper;
+
+import com.google.common.collect.ImmutableList;
+import io.jenkins.plugins.tuleap_api.client.Project;
+import io.jenkins.plugins.tuleap_api.client.ProjectApi;
+import io.jenkins.plugins.tuleap_api.client.UserGroup;
+import io.jenkins.plugins.tuleap_api.client.authentication.AccessToken;
+import io.jenkins.plugins.tuleap_api.client.authentication.AccessTokenApi;
+import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
+import io.jenkins.plugins.tuleap_oauth.TuleapAuthenticationToken;
+import io.jenkins.plugins.tuleap_oauth.TuleapOAuthClientConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class TuleapGroupHelperTest {
+
+    @Test
+    public void itBuildsExpectedGroupNames() {
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            mock(ProjectApi.class),
+            mock(AccessTokenApi.class)
+        );
+        final UserGroup userGroup = mock(UserGroup.class);
+
+        when(userGroup.getProjectName()).thenReturn("use-me");
+        when(userGroup.getGroupName()).thenReturn("Contributors");
+
+        assertEquals("use-me#Contributors", tuleapGroupHelper.buildJenkinsName(userGroup));
+    }
+
+    @Test
+    public void itReturnsTrueIfGroupNameIsOfTuleapFormat() {
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            mock(ProjectApi.class),
+            mock(AccessTokenApi.class)
+        );
+
+        assertTrue(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-me#Contributors"));
+        assertFalse(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-me#Contributors#test"));
+        assertFalse(tuleapGroupHelper.groupNameIsOfTuleapFormat("use-meContributorstest"));
+    }
+
+    @Test
+    public void itReturnsFalseIfProjectDoesNotExistOnTuleapServer() throws ProjectNotFoundException {
+        final ProjectApi projectApi = mock(ProjectApi.class);
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
+        final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            projectApi,
+            mock(AccessTokenApi.class)
+        );
+
+        when(projectApi.getProjectByShortname(anyString(), any())).thenThrow(new ProjectNotFoundException("whatever"));
+
+        assertFalse(tuleapGroupHelper.groupExistsOnTuleapServer("whatever", tuleapAuthenticationToken, tuleapOAuthClientConfiguration));
+    }
+
+    @Test
+    public void itReturnsFalsIfGroupIsNotPresentOnServer() throws ProjectNotFoundException {
+        final ProjectApi projectApi = mock(ProjectApi.class);
+        final Project project = mock(Project.class);
+        final UserGroup userGroup1 = mock(UserGroup.class);
+        final UserGroup userGroup2 = mock(UserGroup.class);
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
+        final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            projectApi,
+            mock(AccessTokenApi.class)
+        );
+
+        when(projectApi.getProjectByShortname(anyString(), any())).thenReturn(project);
+        when(project.getId()).thenReturn(110);
+        when(projectApi.getProjectUserGroups(eq(110), any())).thenReturn(ImmutableList.of(
+            userGroup1,
+            userGroup2
+        ));
+        when(userGroup1.getGroupName()).thenReturn("Contributors");
+        when(userGroup2.getGroupName()).thenReturn("project_members");
+
+        assertFalse(tuleapGroupHelper.groupExistsOnTuleapServer("use-me#whatever", tuleapAuthenticationToken, tuleapOAuthClientConfiguration));
+    }
+
+    @Test
+    public void itReturnsTrueIfGroupIsPresentOnServer() throws ProjectNotFoundException {
+        final ProjectApi projectApi = mock(ProjectApi.class);
+        final Project project = mock(Project.class);
+        final UserGroup userGroup1 = mock(UserGroup.class);
+        final UserGroup userGroup2 = mock(UserGroup.class);
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
+        final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            projectApi,
+            mock(AccessTokenApi.class)
+        );
+
+        when(projectApi.getProjectByShortname(anyString(), any())).thenReturn(project);
+        when(project.getId()).thenReturn(110);
+        when(projectApi.getProjectUserGroups(eq(110), any())).thenReturn(ImmutableList.of(
+            userGroup1,
+            userGroup2
+        ));
+        when(userGroup1.getGroupName()).thenReturn("Contributors");
+        when(userGroup2.getGroupName()).thenReturn("project_members");
+
+        assertTrue(tuleapGroupHelper.groupExistsOnTuleapServer("use-me#Contributors", tuleapAuthenticationToken, tuleapOAuthClientConfiguration));
+    }
+
+    @Test
+    public void itWillAttemptToRefreshTokenIfTuleapGivesAnErrorResponse() throws ProjectNotFoundException {
+        final ProjectApi projectApi = mock(ProjectApi.class);
+        final AccessTokenApi accessTokenApi = mock(AccessTokenApi.class);
+        final AccessToken accessToken = mock(AccessToken.class);
+        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
+        final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
+            projectApi,
+            accessTokenApi
+        );
+
+        when(projectApi.getProjectByShortname(anyString(), any())).thenThrow(new RuntimeException()).thenReturn(mock(Project.class));
+        when(projectApi.getProjectUserGroups(any(), any())).thenReturn(ImmutableList.of());
+        when(accessTokenApi.refreshToken(any(), any(), any())).thenReturn(accessToken);
+
+        tuleapGroupHelper.groupExistsOnTuleapServer("whatever", tuleapAuthenticationToken, tuleapOAuthClientConfiguration);
+        verify(tuleapAuthenticationToken, times(1)).setAccessToken(accessToken);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.tuleap_oauth.helper;
 
 import com.google.common.collect.ImmutableList;
+import io.jenkins.plugins.tuleap_api.client.ProjectApi;
 import io.jenkins.plugins.tuleap_api.client.UserApi;
 import io.jenkins.plugins.tuleap_api.client.UserGroup;
 import io.jenkins.plugins.tuleap_api.client.authentication.AccessToken;
+import io.jenkins.plugins.tuleap_api.client.authentication.AccessTokenApi;
 import org.acegisecurity.GrantedAuthority;
 import org.junit.Test;
 
@@ -19,7 +21,8 @@ public class UserAuthoritiesRetrieverTest {
     public void itReturnsAListOfAuthoritiesMadeOfTuleapGroups() {
         final UserApi userApi = mock(UserApi.class);
         final AccessToken accessToken = mock(AccessToken.class);
-        final UserAuthoritiesRetriever userAuthoritiesRetriever = new UserAuthoritiesRetriever(userApi);
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(mock(ProjectApi.class), mock(AccessTokenApi.class));
+        final UserAuthoritiesRetriever userAuthoritiesRetriever = new UserAuthoritiesRetriever(userApi, tuleapGroupHelper);
         final UserGroup userGroup1 = mock(UserGroup.class);
         final UserGroup userGroup2 = mock(UserGroup.class);
 


### PR DESCRIPTION
This is a part of [story #14018](https://tuleap.net/plugins/tracker/?aid=14018) have a central management of users and groups using oauth

From now on, groups are not inferred from token anymore. In order to
test this patch you can:

* Deploy this plugin
* On Tuleap: As a project admin create a group your are not member of in your project
* On Jenkins: add this group in the authorization Matrix: it should
  behave correctly.

You can also try to invalidate tokens on your Tuleap to check that they
are effectively refreshed.