### PR TITLE
Bump tuleap-api version and fix deprecated call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>tuleap-api</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetriever.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetriever.java
@@ -21,7 +21,7 @@ public class UserAuthoritiesRetriever {
     }
 
     public List<GrantedAuthority> getAuthoritiesForUser(final AccessToken accessToken) {
-        final List<UserGroup> userGroups = this.userApi.getUserMembershipName(accessToken);
+        final List<UserGroup> userGroups = this.userApi.getUserMembership(accessToken);
 
         return userGroups.stream()
             .map(userGroup -> new GrantedAuthorityImpl(this.tuleapGroupHelper.buildJenkinsName(userGroup)))

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
@@ -31,7 +31,7 @@ public class UserAuthoritiesRetrieverTest {
         when(userGroup1.getGroupName()).thenReturn("project_members");
         when(userGroup2.getGroupName()).thenReturn("project_admins");
 
-        when(userApi.getUserMembershipName(accessToken)).thenReturn(ImmutableList.of(userGroup1,userGroup2));
+        when(userApi.getUserMembership(accessToken)).thenReturn(ImmutableList.of(userGroup1,userGroup2));
 
         final List<GrantedAuthority> authorities = userAuthoritiesRetriever.getAuthoritiesForUser(accessToken);
         assertEquals(authorities.size(), 2);


### PR DESCRIPTION
This is a part of [story #14018](https://tuleap.net/plugins/tracker/?aid=14018) have a central management of users and groups using oauth