### PR TITLE
Stop refreshing access tokens

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
@@ -65,7 +65,7 @@ public class TuleapSecurityRealm extends SecurityRealm {
 
     public static final String AUTHORIZATION_ENDPOINT = "oauth2/authorize?";
 
-    public static final String SCOPES = "read:project read:user_membership openid profile email offline_access";
+    public static final String SCOPES = "read:project read:user_membership openid profile email";
     public static final String CODE_CHALLENGE_METHOD = "S256";
 
     private transient AuthorizationCodeChecker authorizationCodeChecker;

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImpl.java
@@ -48,7 +48,6 @@ public class TuleapAuthorizationCodeUrlBuilderImpl implements TuleapAuthorizatio
 
         return tuleapUri + TuleapSecurityRealm.AUTHORIZATION_ENDPOINT +
             "response_type=code" +
-            "&prompt=consent" +
             "&client_id=" + URLEncoder.encode(clientId, UTF_8.name()) +
             "&redirect_uri=" + redirectUri +
             "&scope=" + URLEncoder.encode(TuleapSecurityRealm.SCOPES, UTF_8.name()) +

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import io.jenkins.plugins.tuleap_api.client.Project;
 import io.jenkins.plugins.tuleap_api.client.ProjectApi;
 import io.jenkins.plugins.tuleap_api.client.UserGroup;
-import io.jenkins.plugins.tuleap_api.client.authentication.AccessTokenApi;
 import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
 import io.jenkins.plugins.tuleap_oauth.TuleapAuthenticationToken;
 import io.jenkins.plugins.tuleap_oauth.TuleapOAuthClientConfiguration;
@@ -16,15 +15,10 @@ public class TuleapGroupHelper {
     public static final String GROUP_SEPARATOR = "#";
 
     private final ProjectApi projectApi;
-    private final AccessTokenApi accessTokenApi;
 
     @Inject
-    public TuleapGroupHelper(
-        final ProjectApi projectApi,
-        final AccessTokenApi accessTokenApi
-    ) {
+    public TuleapGroupHelper(final ProjectApi projectApi) {
         this.projectApi = projectApi;
-        this.accessTokenApi = accessTokenApi;
     }
 
     public String buildJenkinsName(UserGroup userGroup) {
@@ -62,15 +56,7 @@ public class TuleapGroupHelper {
         final TuleapAuthenticationToken authenticationToken,
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
     ) {
-        try {
-            return this.projectApi.getProjectUserGroups(project.getId(), authenticationToken.getAccessToken());
-        } catch (RuntimeException exception) {
-            this.tryToRefreshAccessToken(
-                authenticationToken,
-                tuleapOAuthClientConfiguration
-            );
-            return this.projectApi.getProjectUserGroups(project.getId(), authenticationToken.getAccessToken());
-        }
+        return this.projectApi.getProjectUserGroups(project.getId(), authenticationToken.getAccessToken());
     }
 
     private Project getProjectFromTuleapServer(
@@ -78,28 +64,7 @@ public class TuleapGroupHelper {
         final TuleapAuthenticationToken authenticationToken,
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
     ) throws ProjectNotFoundException{
-        try {
-            return this.projectApi.getProjectByShortname(shortName, authenticationToken.getAccessToken());
-        } catch (RuntimeException exception) {
-            this.tryToRefreshAccessToken(
-                authenticationToken,
-                tuleapOAuthClientConfiguration
-            );
-            return this.projectApi.getProjectByShortname(shortName, authenticationToken.getAccessToken());
-        }
-    }
-
-    private void tryToRefreshAccessToken(
-        final TuleapAuthenticationToken authenticationToken,
-        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration
-    ) {
-        authenticationToken.setAccessToken(
-            this.accessTokenApi.refreshToken(
-                authenticationToken.getAccessToken(),
-                tuleapOAuthClientConfiguration.getClientId(),
-                tuleapOAuthClientConfiguration.getClientSecret()
-            )
-        );
+        return this.projectApi.getProjectByShortname(shortName, authenticationToken.getAccessToken());
     }
 
     private String getTuleapProjectName(String groupName) {

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapAuthorizationCodeUrlBuilderImplTest.java
@@ -76,10 +76,9 @@ public class TuleapAuthorizationCodeUrlBuilderImplTest {
 
         String expectedUri = "https://tuleap.example.com/oauth2/authorize?" +
             "response_type=code" +
-            "&prompt=consent" +
             "&client_id=123" +
             "&redirect_uri=" + URLEncoder.encode("https://jenkins.example.com/securityRealm/finishLogin", UTF_8.name()) +
-            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile email offline_access", UTF_8.name()) +
+            "&scope="+ URLEncoder.encode("read:project read:user_membership openid profile email", UTF_8.name()) +
             "&state=Brabus" +
             "&code_challenge=B35S" +
             "&code_challenge_method=S256" +

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelperTest.java
@@ -21,10 +21,7 @@ public class TuleapGroupHelperTest {
 
     @Test
     public void itBuildsExpectedGroupNames() {
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            mock(ProjectApi.class),
-            mock(AccessTokenApi.class)
-        );
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(mock(ProjectApi.class));
         final UserGroup userGroup = mock(UserGroup.class);
 
         when(userGroup.getProjectName()).thenReturn("use-me");
@@ -35,10 +32,7 @@ public class TuleapGroupHelperTest {
 
     @Test
     public void itReturnsTrueIfGroupNameIsOfTuleapFormat() {
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            mock(ProjectApi.class),
-            mock(AccessTokenApi.class)
-        );
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(mock(ProjectApi.class));
 
         assertTrue(tuleapGroupHelper.groupNameIsInTuleapFormat("use-me#Contributors"));
         assertFalse(tuleapGroupHelper.groupNameIsInTuleapFormat("use-me#Contributors#test"));
@@ -50,10 +44,7 @@ public class TuleapGroupHelperTest {
         final ProjectApi projectApi = mock(ProjectApi.class);
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
         final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            projectApi,
-            mock(AccessTokenApi.class)
-        );
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(projectApi);
 
         when(projectApi.getProjectByShortname(anyString(), any())).thenThrow(new ProjectNotFoundException("whatever"));
 
@@ -68,10 +59,7 @@ public class TuleapGroupHelperTest {
         final UserGroup userGroup2 = mock(UserGroup.class);
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
         final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            projectApi,
-            mock(AccessTokenApi.class)
-        );
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(projectApi);
 
         when(projectApi.getProjectByShortname(anyString(), any())).thenReturn(project);
         when(project.getId()).thenReturn(110);
@@ -93,10 +81,7 @@ public class TuleapGroupHelperTest {
         final UserGroup userGroup2 = mock(UserGroup.class);
         final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
         final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            projectApi,
-            mock(AccessTokenApi.class)
-        );
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(projectApi);
 
         when(projectApi.getProjectByShortname(anyString(), any())).thenReturn(project);
         when(project.getId()).thenReturn(110);
@@ -108,25 +93,5 @@ public class TuleapGroupHelperTest {
         when(userGroup2.getGroupName()).thenReturn("project_members");
 
         assertTrue(tuleapGroupHelper.groupExistsOnTuleapServer("use-me#Contributors", tuleapAuthenticationToken, tuleapOAuthClientConfiguration));
-    }
-
-    @Test
-    public void itWillAttemptToRefreshTokenIfTuleapGivesAnErrorResponse() throws ProjectNotFoundException {
-        final ProjectApi projectApi = mock(ProjectApi.class);
-        final AccessTokenApi accessTokenApi = mock(AccessTokenApi.class);
-        final AccessToken accessToken = mock(AccessToken.class);
-        final TuleapOAuthClientConfiguration tuleapOAuthClientConfiguration = mock(TuleapOAuthClientConfiguration.class);
-        final TuleapAuthenticationToken tuleapAuthenticationToken = mock(TuleapAuthenticationToken.class);
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(
-            projectApi,
-            accessTokenApi
-        );
-
-        when(projectApi.getProjectByShortname(anyString(), any())).thenThrow(new RuntimeException()).thenReturn(mock(Project.class));
-        when(projectApi.getProjectUserGroups(any(), any())).thenReturn(Collections.emptyList());
-        when(accessTokenApi.refreshToken(any(), any(), any())).thenReturn(accessToken);
-
-        tuleapGroupHelper.groupExistsOnTuleapServer("whatever", tuleapAuthenticationToken, tuleapOAuthClientConfiguration);
-        verify(tuleapAuthenticationToken, times(1)).setAccessToken(accessToken);
     }
 }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/helper/UserAuthoritiesRetrieverTest.java
@@ -4,7 +4,6 @@ import io.jenkins.plugins.tuleap_api.client.ProjectApi;
 import io.jenkins.plugins.tuleap_api.client.UserApi;
 import io.jenkins.plugins.tuleap_api.client.UserGroup;
 import io.jenkins.plugins.tuleap_api.client.authentication.AccessToken;
-import io.jenkins.plugins.tuleap_api.client.authentication.AccessTokenApi;
 import org.acegisecurity.GrantedAuthority;
 import org.junit.Test;
 
@@ -21,7 +20,7 @@ public class UserAuthoritiesRetrieverTest {
     public void itReturnsAListOfAuthoritiesMadeOfTuleapGroups() {
         final UserApi userApi = mock(UserApi.class);
         final AccessToken accessToken = mock(AccessToken.class);
-        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(mock(ProjectApi.class), mock(AccessTokenApi.class));
+        final TuleapGroupHelper tuleapGroupHelper = new TuleapGroupHelper(mock(ProjectApi.class));
         final UserAuthoritiesRetriever userAuthoritiesRetriever = new UserAuthoritiesRetriever(userApi, tuleapGroupHelper);
         final UserGroup userGroup1 = mock(UserGroup.class);
         final UserGroup userGroup2 = mock(UserGroup.class);


### PR DESCRIPTION
This change is part of [request #14018](https://tuleap.net/plugins/tracker/?aid=14018)

You shouldn't be prompted for approval for every connection anymore as
we do not require the offline_access anymore. This isn't the correct way
to deal with token expiration on the client side and as long as we don't
have a proper way of handling this (being able to pass the user through
complete reauthentication) we prefer to avoid any black magic to deal
with it.