### PR TITLE
Fix the version number in the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>tuleap-oauth</artifactId>
-    <version>${revision}${changelist}</version>
+    <version>${revision}</version>
     <packaging>hpi</packaging>
     <properties>
         <revision>1.1.13</revision>


### PR DESCRIPTION
We want to keep the $MAJOR.$MINOR.$PATCH patern.
Without this change, the pattern would be: $MAJOR.$MINOR.$PATCH-$CHANGELIST

