### PR TITLE
The plugin cannot be released.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [validate]
     if: needs.validate.outputs.should_release == 'true'
+    permissions:
+      contents: write
     steps:
       - name: Check out
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
It cannot be released because the github token does not have sufficient permssion
to access to the github API.

