### PR TITLE
Fix the version release in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>1.1.13</revision>
+        <revision>1.1.14</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/tuleap-oauth-plugin</gitHubRepo>
         <jenkins.version>2.249.1</jenkins.version>


### PR DESCRIPTION
During a test which use the new incremental release, a new version of the
plugin has been pushed in Artifactory but nothing has been done in the
GitHub's side of the plugin. The consequence is when we try to make a new
release, an error is displayed because we try to push to Artifactory a
already existing Jenkins version.

This contribution tends to fix that.
