### PR TITLE
Remove the Findbugs plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,11 +135,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.5</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                 </plugin>


### PR DESCRIPTION
[request #2716](https://tuleap.net/plugins/tracker/?tracker=140&aid=27160) Remove the Findbug plugin in the Tuleap Jenkins plugins

`mvn clean install` should still pass