### PR TITLE
Take into account that the Bearer token type is expected to be capitalized

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AccessTokenCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AccessTokenCheckerImpl.java
@@ -13,7 +13,7 @@ public class AccessTokenCheckerImpl implements AccessTokenChecker {
 
     @Override
     public boolean checkResponseBody(AccessToken accessToken){
-        if (!accessToken.getTokenType().equals(ACCESS_TOKEN_TYPE)) {
+        if (!accessToken.getTokenType().equalsIgnoreCase(ACCESS_TOKEN_TYPE)) {
             LOGGER.log(Level.WARNING, "Bad token type returned");
             return false;
         }

--- a/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/AccessTokenCheckerImplTest.java
+++ b/src/test/java/io/jenkins/plugins/tuleap_oauth/checks/AccessTokenCheckerImplTest.java
@@ -20,9 +20,18 @@ public class AccessTokenCheckerImplTest {
 
 
     @Test
-    public void testResponseBodyReturnsTrueWhenAllChecksAreOk() {
+    public void testResponseBodyReturnsTrueWhenAllChecksAreOkWithCapitalizedBearerTokenType() {
+        responseBodyReturnsTrueWhenAllChecksAreOk("Bearer");
+    }
+
+    @Test
+    public void testResponseBodyReturnsTrueWhenAllChecksAreOkWithAllLowercaseBearerTokenType() {
+        responseBodyReturnsTrueWhenAllChecksAreOk("bearer");
+    }
+
+    public void responseBodyReturnsTrueWhenAllChecksAreOk(String tokenType) {
         AccessToken representation = mock(AccessToken.class);
-        when(representation.getTokenType()).thenReturn("bearer");
+        when(representation.getTokenType()).thenReturn(tokenType);
         when(representation.getExpiresIn()).thenReturn("1202424");
         when(representation.getIdToken()).thenReturn("ignseojseogjiosevjazfoaz");
 


### PR DESCRIPTION
Part of [request #28282](https://tuleap.net/plugins/tracker/?aid=28282): Token type Bearer should be capitalized in the OAuth2 access token

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
