### PR TITLE
fix: Be able to release the plugin via GHA again

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,8 @@ permissions: read-all
 
 jobs:
   maven-cd:
+    permissions:
+      contents: write
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}


### PR DESCRIPTION
By default, permission is `read-all` the consequence is that we cannot update the release note or push a new tag when using Jenkins action `github-reusable-workflows`.
