### PR TITLE
Use Nix to setup a reproducible dev and build environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShellNoCC {
+  buildInputs = [
+    pkgs.maven
+    pkgs.jdk
+  ];
+}


### PR DESCRIPTION
Part of [request #30007](https://tuleap.net/plugins/tracker/?aid=30007) Use Nix to setup a reproducible dev and build environment in the Jenkins plugin

How to test:
 - Write in your terminal: nix-shell => You are in the nix shell
 - do: `java -version` => the Java version is displayed (currently it is 17.0.4)
 - do: `mvn -v` => The Maven version is displayed (currently it is 3.8.6)
