### PR TITLE
Build the plugin with Java 11 instead

### DIFF
--- a/.github/workflows/Archive_Plugin_Artifact.yml
+++ b/.github/workflows/Archive_Plugin_Artifact.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v3.8.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: Build
         run: mvn -Dmaven.test.skip=true -Dspotbugs.skip=true --batch-mode --show-version clean install 
       - name: Archive

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3.8.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
       - name: Build
         run: mvn -Pjacoco clean verify --batch-mode --show-version
       - name: Upload coverage to Codecov

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
[request #30006](https://tuleap.net/plugins/tracker/?aid=30006) Build Tuleap Authentication with Java 11

There is no need to use Java 17 since, the Java version used to release the plugin is 11

No functional change expected