### PR TITLE
Fixes SECURITY-3229: State is not verified in constant time

### DIFF
--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AuthorizationCodeCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AuthorizationCodeCheckerImpl.java
@@ -6,8 +6,11 @@ import io.jenkins.plugins.tuleap_oauth.helper.PluginHelper;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.security.MessageDigest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class AuthorizationCodeCheckerImpl implements AuthorizationCodeChecker {
     private static final Logger LOGGER = Logger.getLogger(AuthorizationCodeCheckerImpl.class.getName());
@@ -54,7 +57,7 @@ public class AuthorizationCodeCheckerImpl implements AuthorizationCodeChecker {
             return false;
         }
 
-        if (!state.equals(expectedState)) {
+        if (!MessageDigest.isEqual(state.getBytes(UTF_8), expectedState.getBytes(UTF_8))) {
             LOGGER.log(Level.WARNING, "expected state and provided state does not match");
             return false;
         }


### PR DESCRIPTION
This opens up the door for timing attacks. In this situation the security impacts appears to be inexistant/quite limited:
* the state is a 128 bits random number, retrieving it via a timing attack seems unlikely in the timeframe of its usefulness (1 mn)
* PKCE is used (and enforced on the OP side) so the flow is still binded to the RP
