### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
         </dependency>

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapSecurityRealm.java
@@ -34,7 +34,7 @@ import io.jenkins.plugins.tuleap_server_configuration.TuleapConfiguration;
 import jenkins.model.Jenkins;
 import jenkins.security.SecurityListener;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.*;
 import org.kohsuke.stapler.verb.POST;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AuthorizationCodeCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/AuthorizationCodeCheckerImpl.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.tuleap_oauth.checks;
 import com.google.inject.Inject;
 import io.jenkins.plugins.tuleap_oauth.TuleapSecurityRealm;
 import io.jenkins.plugins.tuleap_oauth.helper.PluginHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.security.MessageDigest;

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/IDTokenCheckerImpl.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/checks/IDTokenCheckerImpl.java
@@ -12,7 +12,7 @@ import com.google.inject.Inject;
 import io.jenkins.plugins.tuleap_api.client.authentication.OpenIDClientApi;
 import io.jenkins.plugins.tuleap_oauth.TuleapSecurityRealm;
 import io.jenkins.plugins.tuleap_oauth.helper.PluginHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.List;

--- a/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
+++ b/src/main/java/io/jenkins/plugins/tuleap_oauth/helper/TuleapGroupHelper.java
@@ -7,7 +7,7 @@ import io.jenkins.plugins.tuleap_api.client.UserGroup;
 import io.jenkins.plugins.tuleap_api.client.exceptions.ProjectNotFoundException;
 import io.jenkins.plugins.tuleap_oauth.TuleapAuthenticationToken;
 import io.jenkins.plugins.tuleap_oauth.TuleapOAuthClientConfiguration;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` and declared
  `io.jenkins.plugins:commons-lang3-api`. Kept as a package rename because `countMatches` has no
  clean JDK equivalent and `StringUtils.split` has separator-character semantics `String.split`
  does not reproduce.

### Testing done

`mvn -B -ntp clean verify` passes locally on JDK 17.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `4.64`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
